### PR TITLE
Add health check endpoint to FastAPI API

### DIFF
--- a/api.py
+++ b/api.py
@@ -207,6 +207,23 @@ async def generate_podcast(request: PodcastRequest):
         headers={"Content-Disposition": "attachment; filename=podcast.mp3"}
     )
 
+@app.get("/health")
+async def health_check():
+    """Health check endpoint to verify API status."""
+    try:
+        # Check if GEMINI_API_KEY is configured
+        api_key = os.environ.get("GEMINI_API_KEY")
+        api_key_configured = bool(api_key)
+        
+        return {
+            "status": "healthy",
+            "service": "Podcast Audio Generator API",
+            "version": "1.0.0",
+            "api_key_configured": api_key_configured
+        }
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Service unhealthy: {str(e)}")
+
 @app.get("/")
 async def root():
     return {"message": "Podcast Audio Generator API", "docs": "/docs"}

--- a/test_health.py
+++ b/test_health.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+# Add the parent directory to sys.path to import api
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from api import app
+
+class TestHealthEndpoint(unittest.TestCase):
+    """Test cases for the health check endpoint."""
+    
+    def setUp(self):
+        """Set up test client."""
+        self.client = TestClient(app)
+    
+    def test_health_endpoint_with_api_key(self):
+        """Test health endpoint when GEMINI_API_KEY is configured."""
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "test-api-key"}):
+            response = self.client.get("/health")
+            
+            self.assertEqual(response.status_code, 200)
+            
+            data = response.json()
+            self.assertEqual(data["status"], "healthy")
+            self.assertEqual(data["service"], "Podcast Audio Generator API")
+            self.assertEqual(data["version"], "1.0.0")
+            self.assertTrue(data["api_key_configured"])
+    
+    def test_health_endpoint_without_api_key(self):
+        """Test health endpoint when GEMINI_API_KEY is not configured."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove GEMINI_API_KEY if it exists
+            if "GEMINI_API_KEY" in os.environ:
+                del os.environ["GEMINI_API_KEY"]
+            
+            response = self.client.get("/health")
+            
+            self.assertEqual(response.status_code, 200)
+            
+            data = response.json()
+            self.assertEqual(data["status"], "healthy")
+            self.assertEqual(data["service"], "Podcast Audio Generator API")
+            self.assertEqual(data["version"], "1.0.0")
+            self.assertFalse(data["api_key_configured"])
+    
+    def test_health_endpoint_response_structure(self):
+        """Test that health endpoint returns all expected fields."""
+        response = self.client.get("/health")
+        
+        self.assertEqual(response.status_code, 200)
+        
+        data = response.json()
+        expected_fields = ["status", "service", "version", "api_key_configured"]
+        
+        for field in expected_fields:
+            self.assertIn(field, data, f"Missing field: {field}")
+    
+    def test_health_endpoint_method_not_allowed(self):
+        """Test that POST method is not allowed on health endpoint."""
+        response = self.client.post("/health")
+        self.assertEqual(response.status_code, 405)
+    
+    def test_root_endpoint_still_works(self):
+        """Test that the root endpoint still works after adding health endpoint."""
+        response = self.client.get("/")
+        
+        self.assertEqual(response.status_code, 200)
+        
+        data = response.json()
+        self.assertEqual(data["message"], "Podcast Audio Generator API")
+        self.assertEqual(data["docs"], "/docs")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add GET /health endpoint to check API status
- Returns status, service name, version, and API key configuration status
- Create comprehensive test suite for health endpoint
- Test API key presence/absence scenarios
- Verify response structure and HTTP methods

Fixes #3